### PR TITLE
example config error and blkmond cosmetic tweak

### DIFF
--- a/blkmond
+++ b/blkmond
@@ -668,7 +668,7 @@ class NodeConn(asyncore.dispatcher):
 
 if __name__ == '__main__':
 	if len(sys.argv) != 2:
-		print "Usage: blkmon.py CONFIG-FILE"
+		print "Usage: blkmond CONFIG-FILE"
 		sys.exit(1)
 
 	f = open(sys.argv[1])

--- a/example-cfg.json
+++ b/example-cfg.json
@@ -29,7 +29,7 @@
 		"password" : "mypass",
 
 		"stmt.pwdb" :
-		  "SELECT password FROM pool_worker WHERE username = '%s'"
+		  "SELECT password FROM pool_worker WHERE username = ?"
 
 		# ... or ...
 


### PR DESCRIPTION
MySQL stmt.pwd should use prepared statements.

blkmond usage message tweak.
