### PR TITLE
Memcached

### DIFF
--- a/config.c
+++ b/config.c
@@ -183,8 +183,12 @@ static void parse_memcached(const json_t *obj)
 {
 	json_t *servers;
 
-	if (!json_is_object(obj))
+	if (!json_is_object(obj)) {
+		/* No memcached config so don't use it. */
+		memcached_free(srv.mc);
+		srv.mc = NULL;
 		return;
+	}
 
 	servers = json_object_get(obj, "servers");
 	if (json_is_array(servers)) {

--- a/server.c
+++ b/server.c
@@ -1323,7 +1323,8 @@ err_out:
 		worker_log_expire(time(NULL) + 1);
 		htab_free(srv.workers);
 
-		memcached_free(srv.mc);
+		if (srv.mc)
+			memcached_free(srv.mc);
 
 		event_base_free(srv.evbase_main);
 	}


### PR DESCRIPTION
Makes memcached disablible both at build and runtime.
It isn't necessary on smaller servers or in situations where the DB server has way more memory than the RPC server.
