### PR TITLE
Fixed compile under OS X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,5 +12,5 @@ pushpoold_SOURCES = anet.h elist.h htab.h protocol.h server.h ubbp.h	\
 		    db-sqlite.c db-mysql.c db-postgresql.c
 pushpoold_LDFLAGS = $(PTHREAD_FLAGS)
 pushpoold_LDADD	= @LIBCURL@ @EVENT_LIBS@ @PTHREAD_LIBS@ @JANSSON_LIBS@ \
-		  @CRYPTO_LIBS@ @Z_LIBS@ @LIBMEMCACHED_LIBS@ \
+		  @CRYPTO_LIBS@ @Z_LIBS@ @LIBMEMCACHED_LIBS@ @ARGP_LIBS@ \
 		  @SQLITE3_LDFLAGS@ @MYSQL_LDFLAGS@ @POSTGRESQL_LDFLAGS@

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_CHECK_LIB(crypto, MD5_Init, CRYPTO_LIBS=-lcrypto,
   [AC_MSG_ERROR([Missing required OpenSSL library])])
 AC_CHECK_LIB(memcached, memcached_get, LIBMEMCACHED_LIBS=-lmemcached,
   [AC_MSG_ERROR([Missing required libmemcached library])])
+AC_CHECK_LIB(argp, argp_parse, ARGP_LIBS=-largp)
 
 PKG_PROG_PKG_CONFIG()
 
@@ -61,6 +62,7 @@ AC_SUBST(CRYPTO_LIBS)
 AC_SUBST(Z_LIBS)
 AC_SUBST(SQLITE3_LIBS)
 AC_SUBST(LIBMEMCACHED_LIBS)
+AC_SUBST(ARGP_LIBS)
 
 AC_CONFIG_FILES([
 	Makefile

--- a/msg.c
+++ b/msg.c
@@ -27,7 +27,16 @@
 #include <unistd.h>
 #include <string.h>
 #include <jansson.h>
+
+#if defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#define le32toh OSSwapLittleToHostInt32
+#define htole32 OSSwapHostToLittleInt32
+#define bswap_32 OSSwapInt32
+#else
 #include <byteswap.h>
+#endif
+
 #include <openssl/sha.h>
 #include <syslog.h>
 #include "server.h"

--- a/server.c
+++ b/server.c
@@ -38,7 +38,15 @@
 #include <zlib.h>
 #include <netdb.h>
 #include <stdarg.h>
+
+#if defined(__APPLE__)
+#include <machine/endian.h>
+#define htole32 OSSwapHostToLittleInt32
+#define le32toh OSSwapLittleToHostInt32
+#else
 #include <endian.h>
+#endif
+
 #include <openssl/sha.h>
 #include <argp.h>
 #include "server.h"

--- a/server.c
+++ b/server.c
@@ -40,6 +40,7 @@
 #include <stdarg.h>
 
 #if defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
 #include <machine/endian.h>
 #define htole32 OSSwapHostToLittleInt32
 #define le32toh OSSwapLittleToHostInt32


### PR DESCRIPTION
These commits should allow pushpool to build correctly under OS X. Had to deal with the byteswap / endian header file issues as well as the argp differences. Should also document that libargp-standalone needs to be installed on OS X in order to build. FreeBSD support should follow pretty easily from this I think, but I don't currently have a system up to test it on.

Thanks!
