### PR TITLE
cjson_decode: properly pass destination buffer size to uncompress

### DIFF
--- a/server.c
+++ b/server.c
@@ -172,6 +172,7 @@ static json_t *cjson_decode(void *buf, size_t buflen)
 	obj_unc = malloc(unc_len + 1);
 	if (!obj_unc)
 		return NULL;
+	dest_len = unc_len;
 
 	/* decompress buffer (excluding first 32 bits) */
 	comp_p = buf + 4;


### PR DESCRIPTION
Reported by elmigranto

From zlib manual:
_Upon entry, destLen is the total size of the destination buffer, which must be large enough to hold the entire uncompressed data._
