### PR TITLE
option to secure (hash) worker passwords in database

### DIFF
--- a/config.c
+++ b/config.c
@@ -390,6 +390,9 @@ void read_config(void)
 		exit(1);
 	}
 
+  if (json_is_true(json_object_get(jcfg, "password.secure")))
+    srv.secure_password = true;
+
 	if (json_is_true(json_object_get(jcfg, "rpc.target.rewrite")))
 		srv.easy_target = json_string(EASY_TARGET);
 

--- a/example-cfg.json
+++ b/example-cfg.json
@@ -79,6 +79,9 @@
 	# length of time to cache username/password credentials, in seconds
 	"auth.cred_cache.expire" : 75,
 
+  # worker passwords stored as SHA1 hashes for security purposes
+  "password.secure": true,
+
 	# RPC settings
 	"rpc.url" : "http://127.0.0.1:8332/",
 	"rpc.user" : "myusername",

--- a/server.h
+++ b/server.h
@@ -43,6 +43,9 @@
 #define le32toh OSSwapLittleToHostInt32
 #define htole32 OSSwapHostToLittleInt32
 #define bswap_32 OSSwapInt32
+#define WITHOUT_STRNDUP
+/* util.c */
+extern char *strndup(char const *, size_t);
 #else
 #include <byteswap.h>
 #include <endian.h>

--- a/server.h
+++ b/server.h
@@ -170,6 +170,8 @@ struct server {
 	char			*db_stmt_sharelog;
 	void			*db_cxn;
 
+  bool      secure_password;
+
 	struct hist		*hist;
 	unsigned char		cur_prevhash[32];
 

--- a/util.c
+++ b/util.c
@@ -541,3 +541,36 @@ g_base64_decode (const char *text,
   return ret;
 }
 
+
+/* A replacement function, for systems that lack strndup.
+
+   Copyright (C) 1996, 1997, 1998, 2001, 2002, 2003, 2005, 2006, 2007
+   Free Software Foundation, Inc.
+
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the
+   Free Software Foundation; either version 2, or (at your option) any
+   later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  */
+
+#ifdef WITHOUT_STRNDUP
+char *strndup(char const *s, size_t n)
+{
+  size_t len = strnlen (s, n);
+  char *new = malloc (len + 1);
+
+  if (new == NULL)
+    return NULL;
+
+  new[len] = '\0';
+  return memcpy (new, s, len);
+}
+#endif


### PR DESCRIPTION
The next step here would be to add a salt, but this should still be better than storing them plaintext 

(Not because the worker passwords themselves are valuable per se, but rather because many users will probably re-use the same password used elsewhere)

Note that I've made this optional, configured in the config.json by toggling "password.secure" : true. It's false by default for backwards compatibility.
